### PR TITLE
Add HeadDatabase example

### DIFF
--- a/get-started-1/format/README.md
+++ b/get-started-1/format/README.md
@@ -127,3 +127,11 @@ You can use a Base64 string textures.
 {% hint style="success" %}
 \#ICON: PLAYER\_HEAD (`eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODE2ZjAwNzNjNTg3MDNkOGQ0MWU1NWUwYTNhYmIwNDJiNzNmOGMxMDViYzQxYzJmMDJmZmUzM2YwMzgzY2YwYSJ9fX0=`)
 {% endhint %}
+
+#### HeadDatabase Texture:
+
+This requires the plugin [HeadDatabase](https://www.spigotmc.org/resources/14280/) to be installed.
+
+{% hint style="success" %}
+\#ICON: PLAYER\_HEAD (HEADDATABASE\_1)
+{% endhint %}

--- a/get-started-1/format/README.md
+++ b/get-started-1/format/README.md
@@ -99,11 +99,11 @@ Some Materials and Entity Types will only work on certain versions. For example,
 There are three ways you can create player heads.
 
 {% hint style="warning" %}
-For versions below 1.13, use SKULL\_ITEM instead of PLAYER\_HEAD material.
+For versions below 1.13, use SKULL\_ITEM instead of PLAYER\_HEAD as material.
 {% endhint %}
 
 {% hint style="info" %}
-We used ICON as the line type but these will also work with HEAD and SMALLHEAD.
+The below examples use ICON as the line type, but you can also use HEAD and SMALLHEAD for them.
 {% endhint %}
 
 #### Player Name:


### PR DESCRIPTION
Adds an example for HeadDatabase skull textures to the Formats page.