### PR TITLE
Add note about console action + proxy

### DIFF
--- a/general/actions.md
+++ b/general/actions.md
@@ -33,6 +33,8 @@ Executes a command as the player who clicked.
 
 Executes a command as console.
 
+{% hint style="warning" %} This action will not work for commands provided by either a BungeeCord/Velocity Proxy or plugin. {% endhint %}
+
 #### CONNECT:\<server>
 
 Send the player who clicked to another server. (Bungee only)


### PR DESCRIPTION
Since the `CONSOLE` action executes as the server console does it not work with commands that are provided by BungeeCord/Velocity (Either the proxy itself or a plugin).

This PR adds a note about this, to inform about the limitation. I'm not sure if the `COMMAND` action is also affected by this, or if it runs as it should (I assume it's fine as it should dispatch the command as player, so the Proxy probs would intersect where necessary)