### PR TITLE
Update the Url in get-started.md to the actual path for the repository (Item-NBT-API)

### DIFF
--- a/docs/api/get-started.md
+++ b/docs/api/get-started.md
@@ -57,7 +57,7 @@ repositories {
   // Other repositories, including jitpack
   maven {
     id = "codemc"
-    url = "https://repo.codemc.io/repositories/maven-public/"
+    url = "https://repo.codemc.io/repository/maven-public/"
   }
 }
 ```


### PR DESCRIPTION
The path for the repos is actually `/repository/maven-public` instead of `/repositories/maven-public`, which leads to more errors when trying to use the proposed fix

Wrong: https://repo.codemc.io/repositories/maven-public/

Right: https://repo.papermc.io/repository/maven-public/